### PR TITLE
Bulk edit bookmarks

### DIFF
--- a/src/api/mongodb/index.js
+++ b/src/api/mongodb/index.js
@@ -53,10 +53,24 @@ export function addTag({ bookmarkId, newTag }) {
   return app().callFunction('addTag', [newTag, new BSON.ObjectId(bookmarkId)])
 }
 
+export function bulkAddTag({ bookmarkIds, newTag }) {
+  return app().callFunction('bulkAddTag', [
+    newTag,
+    bookmarkIds.map((x) => new BSON.ObjectId(x)),
+  ])
+}
+
 export function removeTag({ bookmarkId, tagToRemove }) {
   return app().callFunction('removeTag', [
     tagToRemove,
     new BSON.ObjectId(bookmarkId),
+  ])
+}
+
+export function bulkRemoveTag({ bookmarkIds, newTag }) {
+  return app().callFunction('bulkRemoveTag', [
+    newTag,
+    bookmarkIds.map((x) => new BSON.ObjectId(x)),
   ])
 }
 

--- a/src/components/BookmarkRow.vue
+++ b/src/components/BookmarkRow.vue
@@ -3,8 +3,10 @@
     <label class="pr-4 pt-1 hidden md:block">
       <input
         type="checkbox"
+        :checked="isChecked"
         class="rounded border-gray-300 text-blue-500 shadow-sm focus:ring focus:ring-blue-200 focus:ring-opacity-50"
-        v-model="bookmark.selected"
+        @change="onSelect"
+        ref="checkbox"
       />
     </label>
     <div class="px-1 flex-grow space-y-2">
@@ -46,6 +48,21 @@ export default {
       const dateAdded = moment(this.bookmark.dateAdded)
       // ll	-> Sep 4, 1986
       return dateAdded.format('ll')
+    },
+    isChecked() {
+      return this.$store.getters.getBookmarkById(this.bookmarkId).selected
+    },
+  },
+
+  methods: {
+    onSelect() {
+      const actionName = this.$refs.checkbox.checked
+        ? 'BOOKMARK_SELECTED'
+        : 'BOOKMARK_UNSELECTED'
+      this.$store.dispatch({
+        type: actionName,
+        id: this.bookmarkId,
+      })
     },
   },
 }

--- a/src/components/SideBar.vue
+++ b/src/components/SideBar.vue
@@ -1,32 +1,83 @@
 <template>
-  <nav>
-    <p class="text-xs text-muted">{{ pluralized }}</p>
-    <p class="text-2xl text-muted font-bold mt-2">
-      {{ numBookmarks.toLocaleString('en') }}
-    </p>
-    <div v-if="numSelected" class="flex items-end mt-4">
-      <svg
-        class="h-5 w-5 stroke-current text-red-700 cursor-pointer"
-        @click="deleteSelected"
-        viewBox="0 0 24 24"
-        fill="none"
-        xmlns="http://www.w3.org/2000/svg"
+  <div class="space-y-4">
+    <section>
+      <p class="text-xs text-muted">{{ pluralized }}</p>
+      <p class="text-2xl text-muted font-bold mt-2">
+        {{ numBookmarks.toLocaleString('en') }}
+      </p>
+    </section>
+    <section v-if="numSelected" class="space-y-2">
+      <div>
+        <!-- This extra margin is required to offset TagsRow component's
+             default negative left margin :shrug: -->
+        <div class="ml-1">
+          <TagsRow :bookmark-id="bulkEditBookmarkId"></TagsRow>
+        </div>
+      </div>
+      <button
+        class="p-2 border border-default rounded flex items-center bg-default select-none focus:outline-none"
+        @click="clearSelected"
       >
-        <path
-          d="M19 7L18.1327 19.1425C18.0579 20.1891 17.187 21 16.1378 21H7.86224C6.81296 21 5.94208 20.1891 5.86732 19.1425L5 7M10 11V17M14 11V17M15 7V4C15 3.44772 14.5523 3 14 3H10C9.44772 3 9 3.44772 9 4V7M4 7H20"
-          stroke-width="2"
-          stroke-linecap="round"
-          stroke-linejoin="round"
-        />
-      </svg>
-      <span class="ml-1 text-sm text-muted">Delete {{ numSelected }}</span>
-    </div>
-  </nav>
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          class="h-4 w-4 stroke-current text-muted"
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke="currentColor"
+        >
+          <path
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+            d="M15 12H9m12 0a9 9 0 11-18 0 9 9 0 0118 0z"
+          />
+        </svg>
+        <span class="ml-2 text-sm font-medium tracking-wide text-muted"
+          >Unselect</span
+        >
+      </button>
+      <button
+        class="p-2 border border-transparent rounded flex items-center bg-red-600 select-none focus:outline-none"
+        @click="deleteSelected"
+      >
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          class="h-4 w-4 stroke-current text-red-100"
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke="currentColor"
+        >
+          <path
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+            d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"
+          />
+        </svg>
+        <span class="ml-2 text-sm font-medium tracking-wide text-red-100"
+          >Delete</span
+        >
+      </button>
+    </section>
+  </div>
 </template>
 
 <script>
+import TagsRow from './TagsRow.vue'
+import { SENTINEL_BULK_EDIT_BOOKMARK_ID } from './TagsRow.vue'
+
 export default {
   name: 'side-bar',
+
+  components: {
+    TagsRow,
+  },
+
+  data: function () {
+    return {
+      bulkEditBookmarkId: SENTINEL_BULK_EDIT_BOOKMARK_ID,
+    }
+  },
 
   computed: {
     numBookmarks() {
@@ -42,7 +93,10 @@ export default {
 
   methods: {
     deleteSelected() {
-      this.$store.dispatch('BULK_DELETE_BOOKMARKS')
+      this.$store.dispatch('DELETE_SELECTED')
+    },
+    clearSelected() {
+      this.$store.dispatch('CLEAR_SELECTED')
     },
   },
 }

--- a/src/components/TagsRow.vue
+++ b/src/components/TagsRow.vue
@@ -7,14 +7,14 @@
     <button
       class="text-primary h-6 px-1 my-1 mr-2 text-center text-xs rounded border border-primary select-none focus:outline-none"
       v-bind:class="[editMode ? 'bg-default' : 'bg-grey-100']"
-      v-if="bookmark.site"
+      v-if="bookmarkSite"
       @click="tagClicked({ tagType: 'site' })"
     >
-      {{ bookmark.site }}
+      {{ bookmarkSite }}
       <a v-if="filterMode && !editMode" class="tag-link add"></a>
     </button>
     <button
-      v-for="(tag, index) in bookmark.tags"
+      v-for="(tag, index) in bookmarkTags"
       :key="index"
       class="text-primary h-6 px-1 my-1 mr-2 text-center text-xs rounded border border-primary select-none focus:outline-none"
       v-bind:class="[editMode ? 'bg-default' : 'bg-grey-100']"
@@ -52,6 +52,8 @@
 const typeaheadActivationThreshold = 3
 const caseSensitiveTags = false
 
+export const SENTINEL_BULK_EDIT_BOOKMARK_ID = 'WHY NOT ZOIDBERG?'
+
 export default {
   name: 'tags-row',
 
@@ -61,7 +63,11 @@ export default {
 
   data: function () {
     return {
-      editMode: false,
+      bookmarkSite:
+        this.bookmarkId === SENTINEL_BULK_EDIT_BOOKMARK_ID
+          ? null
+          : this.$store.getters.getBookmarkById(this.bookmarkId).site,
+      editMode: this.bookmarkId === SENTINEL_BULK_EDIT_BOOKMARK_ID,
       newTag: '',
       tagSuggestion: '',
     }
@@ -80,7 +86,7 @@ export default {
       if (tagType === 'site') {
         this.$store.dispatch('FILTER_ADDED', {
           ...dataObj,
-          name: this.bookmark.site,
+          name: this.bookmarkSite,
         })
       } else if (tagType === 'tag') {
         this.$store.dispatch('FILTER_ADDED', { ...dataObj, name: tagName })
@@ -102,8 +108,12 @@ export default {
       }
 
       let tag = tagToAdd.trim().replace(/\s+/g, ' ')
-      let dataObj = { id: this.bookmarkId, tag }
-      this.$store.dispatch('ADD_TAG_FOR_BOOKMARK', dataObj)
+      if (this.bookmarkId === SENTINEL_BULK_EDIT_BOOKMARK_ID) {
+        this.$store.dispatch('ADD_TAG_TO_SELECTED', { tag })
+      } else {
+        let dataObj = { id: this.bookmarkId, tag }
+        this.$store.dispatch('ADD_TAG_FOR_BOOKMARK', dataObj)
+      }
 
       this.newTag = ''
     },
@@ -111,8 +121,12 @@ export default {
       if (!tagName) {
         return
       }
-      let dataObj = { id: this.bookmarkId, tag: tagName }
-      this.$store.dispatch('REMOVE_TAG_FROM_BOOKMARK', dataObj)
+      if (this.bookmarkId === SENTINEL_BULK_EDIT_BOOKMARK_ID) {
+        this.$store.dispatch('REMOVE_TAG_FROM_SELECTED', { tag: tagName })
+      } else {
+        let dataObj = { id: this.bookmarkId, tag: tagName }
+        this.$store.dispatch('REMOVE_TAG_FROM_BOOKMARK', dataObj)
+      }
     },
     doSearch(searchQuery) {
       let searchResults = []
@@ -122,7 +136,7 @@ export default {
         const compareable = caseSensitiveTags ? tag : tag.toLowerCase()
         if (
           compareable.startsWith(searchQuery) &&
-          !this.bookmark.tags.includes(compareable)
+          !this.bookmarkTags.includes(compareable)
         ) {
           searchResults.push(tag)
         }
@@ -141,6 +155,10 @@ export default {
       Event.$on('exitEditMode', this.exitEditMode)
     },
     exitEditMode({ currFocusId }) {
+      if (this.bookmarkId === SENTINEL_BULK_EDIT_BOOKMARK_ID) {
+        // Never exit edit mode
+        return
+      }
       if (this.bookmarkId !== currFocusId) {
         this.editMode = false
         this.newTag = ''
@@ -153,13 +171,22 @@ export default {
   },
 
   computed: {
-    bookmark() {
-      return this.$store.getters.getBookmarkById(this.bookmarkId)
+    bookmarkTags() {
+      if (this.bookmarkId === SENTINEL_BULK_EDIT_BOOKMARK_ID) {
+        return this.$store.getters.tagsInBulkEdit
+      }
+      return this.$store.getters.getBookmarkById(this.bookmarkId).tags
     },
     filterMode() {
       return this.$store.state.list.activeType !== 'new'
     },
     placeholder() {
+      if (
+        this.bookmarkId === SENTINEL_BULK_EDIT_BOOKMARK_ID &&
+        !this.newTag.length
+      ) {
+        return 'Add/remove tags to all selected'
+      }
       if (
         !this.newTag.length ||
         this.newTag.length < typeaheadActivationThreshold

--- a/src/components/TagsRow.vue
+++ b/src/components/TagsRow.vue
@@ -182,12 +182,6 @@ export default {
     },
     placeholder() {
       if (
-        this.bookmarkId === SENTINEL_BULK_EDIT_BOOKMARK_ID &&
-        !this.newTag.length
-      ) {
-        return 'Add/remove tags to all selected'
-      }
-      if (
         !this.newTag.length ||
         this.newTag.length < typeaheadActivationThreshold
       ) {

--- a/src/components/TagsRow.vue
+++ b/src/components/TagsRow.vue
@@ -67,7 +67,7 @@ export default {
         this.bookmarkId === SENTINEL_BULK_EDIT_BOOKMARK_ID
           ? null
           : this.$store.getters.getBookmarkById(this.bookmarkId).site,
-      editMode: this.bookmarkId === SENTINEL_BULK_EDIT_BOOKMARK_ID,
+      editMode: this.bookmarkId === SENTINEL_BULK_EDIT_BOOKMARK_ID, // Bulk edit component starts (and remains) in editMode
       newTag: '',
       tagSuggestion: '',
     }

--- a/src/index.js
+++ b/src/index.js
@@ -12,13 +12,6 @@ eventLogger.init(process.env.AMPLITUDE_API_KEY)
 // component to communicate between them.
 window.Event = new Vue()
 
-// Clicking outside tags row input should exit edit mode
-// Inspired from: https://stackoverflow.com/a/36180348/7003143
-// Also see `collapseSiblings` in TagsRow.vue
-document.body.addEventListener('click', (event) => {
-  Event.$emit('exitEditMode', {})
-})
-
 Vue.use(AuthPlugin, {
   domain: process.env.AUTH0_DOMAIN,
   clientId: process.env.AUTH0_CLIENTID,

--- a/src/index.js
+++ b/src/index.js
@@ -49,3 +49,9 @@ app.$auth.$watch('tokenExpiredBeacon', (beacon) => {
 })
 
 app.$mount('#app')
+
+if (process.env.NODE_ENV !== 'production') {
+  if (app.$auth.user) {
+    console.log(`Logged in as: ${app.$auth.user.identities[0].id}`)
+  }
+}

--- a/src/layouts/AppLayout.vue
+++ b/src/layouts/AppLayout.vue
@@ -20,6 +20,9 @@
           <div class="hidden md:block md:col-span-4">
             <SearchBar ref="searchInput"></SearchBar>
           </div>
+          <div v-if="isSaving">
+            <span>Saving...</span>
+          </div>
           <div
             v-if="!$auth.loading"
             class="hidden md:block md:col-start-10 md:justify-self-end text-xs text-muted mr-4"
@@ -72,6 +75,9 @@ export default {
     testMode() {
       return process.env.TEST_MODE === 'true'
     },
+    isSaving() {
+      return this.$store.state.list.save.pending
+    },
   },
 
   methods: {
@@ -100,6 +106,15 @@ export default {
       // Also see `collapseSiblings` in TagsRow.vue
       Event.$emit('exitEditMode', {})
     },
+    beforeUnload(event) {
+      if (this.$store.state.list.save.pending) {
+        // Cancel the event as stated by the standard.
+        event.preventDefault()
+        // Older browsers supported custom message
+        return (event.returnValue =
+          'There is pending work. Sure you want to leave?')
+      }
+    },
     login() {
       // This is a stub. It should never happen. We cannot be in logged-out
       // state while AppLayout is rendered!
@@ -120,6 +135,7 @@ export default {
     window.addEventListener('scroll', this.scrollHandler)
     window.addEventListener('keydown', this.onKeydown)
     document.body.addEventListener('click', this.onClickOutside)
+    window.addEventListener('beforeunload', this.beforeUnload)
     this.$refs.searchInput.focus()
   },
 

--- a/src/layouts/AppLayout.vue
+++ b/src/layouts/AppLayout.vue
@@ -21,7 +21,7 @@
             <SearchBar ref="searchInput"></SearchBar>
           </div>
           <div v-if="isSaving">
-            <span>Saving...</span>
+            <span class="text-sm text-muted">Saving...</span>
           </div>
           <div
             v-if="!$auth.loading"

--- a/src/layouts/AppLayout.vue
+++ b/src/layouts/AppLayout.vue
@@ -94,6 +94,12 @@ export default {
         this.$refs.searchInput.focus()
       }
     },
+    onClickOutside() {
+      // Clicking outside tags row input should exit edit mode
+      // Inspired from: https://stackoverflow.com/a/36180348/7003143
+      // Also see `collapseSiblings` in TagsRow.vue
+      Event.$emit('exitEditMode', {})
+    },
     login() {
       // This is a stub. It should never happen. We cannot be in logged-out
       // state while AppLayout is rendered!
@@ -106,12 +112,14 @@ export default {
   destroyed() {
     window.removeEventListener('scroll', this.scrollHandler)
     window.removeEventListener('keydown', this.onKeydown)
+    document.body.removeEventListener('click', this.onClickOutside)
   },
 
   mounted() {
     this.scrollHandler = _.throttle(this.onScroll, 200)
     window.addEventListener('scroll', this.scrollHandler)
     window.addEventListener('keydown', this.onKeydown)
+    document.body.addEventListener('click', this.onClickOutside)
     this.$refs.searchInput.focus()
   },
 

--- a/src/store/modules/bookmarks.js
+++ b/src/store/modules/bookmarks.js
@@ -21,9 +21,11 @@ function addTag(state, tag) {
 }
 
 function deleteTag(state, tag) {
-  state.tags[tag] -= 1
-  if (state.tags[tag] === 0) {
-    Vue.delete(state.tags, tag)
+  if (state.tags.hasOwnProperty(tag)) {
+    state.tags[tag] -= 1
+    if (state.tags[tag] === 0) {
+      Vue.delete(state.tags, tag)
+    }
   }
 }
 
@@ -199,7 +201,8 @@ const mutations = {
   },
 
   SET_SELECTED: (state, { id, isChecked }) => {
-    // The bookmark might already be nuked by the time we get to this commit. It becomes a no-op then.
+    // The bookmark might already be nuked by the time we get to this commit.
+    // It becomes a no-op then.
     if (state.bookmarks.hasOwnProperty(id)) {
       state.bookmarks[id].selected = isChecked
     }

--- a/src/store/modules/bookmarks.js
+++ b/src/store/modules/bookmarks.js
@@ -200,11 +200,13 @@ const mutations = {
     }
   },
 
-  SET_SELECTED: (state, { id, isChecked }) => {
-    // The bookmark might already be nuked by the time we get to this commit.
-    // It becomes a no-op then.
-    if (state.bookmarks.hasOwnProperty(id)) {
-      state.bookmarks[id].selected = isChecked
+  SET_SELECTED: (state, { ids, isChecked }) => {
+    for (const id of ids) {
+      // The bookmark might already be nuked by the time we get to this commit.
+      // It becomes a no-op then.
+      if (state.bookmarks.hasOwnProperty(id)) {
+        state.bookmarks[id].selected = isChecked
+      }
     }
   },
 }

--- a/src/store/modules/list.js
+++ b/src/store/modules/list.js
@@ -436,9 +436,7 @@ const actions = {
 
   CLEAR_SELECTED: ({ state, commit }) => {
     let currSelected = Array.from(state.bulk.ids)
-    for (let id of currSelected) {
-      commit('SET_SELECTED', { ids: [id], isChecked: false })
-    }
+    commit('SET_SELECTED', { ids: currSelected, isChecked: false })
     commit('CLEAR_BULK_ITEMS')
   },
 }

--- a/src/store/modules/list.js
+++ b/src/store/modules/list.js
@@ -84,8 +84,8 @@ const state = () => ({
   requestId: 0,
   fetchPromise: null, // pending navigation
   save: {
-    // pending save to backend, do not eject!
     operationId: 0,
+    // pending save to backend, do not eject!
     pending: false,
   },
 })
@@ -400,6 +400,8 @@ const actions = {
     commit('REMOVE_FROM_BULK_ITEMS', id)
   },
 
+  // TODO(akshay:2020-12-28): Wrap this design pattern in a function decorator
+  //  to DRY-up code
   ADD_TAG_TO_SELECTED: ({ state, commit, dispatch }, { tag }) => {
     commit('SET_SAVING')
     const myOperationId = state.save.operationId

--- a/src/store/modules/list.js
+++ b/src/store/modules/list.js
@@ -390,13 +390,19 @@ const actions = {
     }
   },
 
+  SELECT_ALL: ({ commit, getters }) => {
+    let activeIds = getters.activeIds
+    commit('SET_SELECTED', { ids: activeIds, isChecked: true })
+    commit('ADD_TO_BULK_ITEMS', activeIds)
+  },
+
   BOOKMARK_SELECTED: ({ state, commit, getters }, { id }) => {
-    commit('SET_SELECTED', { id, isChecked: true })
-    commit('ADD_TO_BULK_ITEMS', id)
+    commit('SET_SELECTED', { ids: [id], isChecked: true })
+    commit('ADD_TO_BULK_ITEMS', [id])
   },
 
   BOOKMARK_UNSELECTED: ({ state, commit }, { id }) => {
-    commit('SET_SELECTED', { id, isChecked: false })
+    commit('SET_SELECTED', { ids: [id], isChecked: false })
     commit('REMOVE_FROM_BULK_ITEMS', id)
   },
 
@@ -431,7 +437,7 @@ const actions = {
   CLEAR_SELECTED: ({ state, commit }) => {
     let currSelected = Array.from(state.bulk.ids)
     for (let id of currSelected) {
-      commit('SET_SELECTED', { id, isChecked: false })
+      commit('SET_SELECTED', { ids: [id], isChecked: false })
     }
     commit('CLEAR_BULK_ITEMS')
   },
@@ -549,9 +555,9 @@ const mutations = {
     }
   },
 
-  ADD_TO_BULK_ITEMS: (state, id) => {
+  ADD_TO_BULK_ITEMS: (state, ids) => {
     const newItems = new Set(state.bulk.ids)
-    newItems.add(id)
+    ids.forEach((id) => newItems.add(id))
     Vue.set(state.bulk, 'ids', newItems)
   },
 


### PR DESCRIPTION
## Summary

Savory has allowed you to select multiple bookmarks for a while, but the only extra affordance it offered was to delete them. With this change, we allow users to add or remove tags to multiple bookmarks at once.

Once you select 1 or more bookmarks, a new UI pops up in the sidebar which shows you a set union of all the tags for selected bookmarks. You can delete a tag from this UI and it will be pruned from all the bookmarks in the selection that have that tag.

Similarly, you can add a new tag via this UI and all the bookmarks in selection will get it.

<img width="234" alt="Screen Shot 2020-12-28 at 4 54 18 PM" src="https://user-images.githubusercontent.com/600362/103211135-5ac2bd80-492d-11eb-9187-51f9c79e8dd4.png">
