### PR TITLE
Disable Chrome autofill for tag input textfield

### DIFF
--- a/src/components/TagsRow.vue
+++ b/src/components/TagsRow.vue
@@ -37,7 +37,7 @@
       <input
         ref="input"
         type="text"
-        autocomplete="off"
+        autocomplete="nope"
         title="Click to add or remove tags"
         v-model="newTag"
         @keydown.tab.prevent="onTab"

--- a/src/components/TagsRow.vue
+++ b/src/components/TagsRow.vue
@@ -37,6 +37,7 @@
       <input
         ref="input"
         type="text"
+        autocomplete="off"
         title="Click to add or remove tags"
         v-model="newTag"
         @keydown.tab.prevent="onTab"


### PR DESCRIPTION
Ran into a surprising bug/feature in Chrome today. When I was trying to add a new tag for a bookmark in Savory, I got an option to autofill my phone number. It had never happened before.

This is the current Chrome version:

```
Google Chrome | 88.0.4324.182 (Official Build) (x86_64)
OS | macOS Version 10.15.7 (Build 19H512)
JavaScript | V8 8.8.278.17
```

It was a curious case since it was not happening with all the bookmarks. It was happening on the most recent link I added. After clicking on random things to try to figure out what's happening, I stumbled upon a page where it was happening on all the bookmarks. 😮 

Turns out, I was on the `mobile` tag filter view. Do you know where this is going?

The [MDN page on autocomplete](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/autocomplete#values) tells us the different values this attribute supports.

> autocomplete lets web developers specify what if any permission the user agent has to provide automated assistance in filling out form field values, as well as guidance to the browser as to the type of information expected in the field.

Chrome goes a step further and tries to infer autofill behavior from name, id or any text content it can get near the text input including labels and arbitrary text nodes. In my case, it was reading the `mobile` tag adjacent to the "add new tag" input field and being overly helpful.

We don't want that.

Disabling this behavior is not standardized and is prone to break from version to version. This domain is a rabbit hole in itself really where developers are trying to get this annoyance fixed since 2012 at least.

https://stackoverflow.com/questions/15738259/disabling-chrome-autofill
https://stackoverflow.com/questions/12374442/chrome-ignores-autocomplete-off
https://developer.mozilla.org/en-US/docs/Web/Security/Securing_your_site/Turning_off_form_autocompletion

Phew!

Anyway, for now `nope` works.

:tada:
