### PR TITLE
Tags with a colon in the name should work

### DIFF
--- a/src/store/modules/list.js
+++ b/src/store/modules/list.js
@@ -7,9 +7,11 @@ import { router } from '../../router'
 
 function getFiltersFromQueryString(filterString) {
   return filterString.split('/').map((filter) => {
-    let peeled = filter.split(':', 2)
-    const type = peeled[0] === 's' ? 'site' : 'tag'
-    const name = peeled[1]
+    // We have to do this dance because `:` can be part of the name of tag
+    const on = ':'
+    let [first, ...rest] = filter.split(on)
+    const type = first === 's' ? 'site' : 'tag'
+    const name = rest.join(on)
     return { type, name }
   })
 }

--- a/src/store/modules/list.js
+++ b/src/store/modules/list.js
@@ -7,7 +7,7 @@ import { router } from '../../router'
 
 function getFiltersFromQueryString(filterString) {
   return filterString.split('/').map((filter) => {
-    let peeled = filter.split(':')
+    let peeled = filter.split(':', 2)
     const type = peeled[0] === 's' ? 'site' : 'tag'
     const name = peeled[1]
     return { type, name }


### PR DESCRIPTION
A thing I invented today on my own, without writing any code, was implicit hierarchies in Savory.

I went ahead and tagged all my indie hackers podcasts with `podcast:ih`.

See the colon right there? It does not mean anything special for Savory, but has a meaning for me. It signifies a "hierarchical" tag.

It _should_ not mean anything different for Savory, except it did. You see Savory uses the url component `t:some tag` and `s:site.com` in filter view for navigation. There was a bug in the parsing logic because `:` is special.

It is still special to us, but the bug is fixed!

Tested on qa!

