### PR TITLE
Fix signup success event

### DIFF
--- a/src/pages/WelcomePage.vue
+++ b/src/pages/WelcomePage.vue
@@ -174,10 +174,10 @@ export default {
     let resp = await ApiClient.loadUserData()
     this.userData = resp.data
     this.$refs.bar.increase(10)
-    if (!this.userData) {
+    if (this.userData.login_count === 1) {
       // We provide `/provider_cb` as the success callback to Auth0 which
-      // redirects to this page. We use empty userData as a proxy for new
-      // user.
+      // redirects to this page. If this is the first login for this user, this
+      // must be a successful signup event.
       eventLogger.logEvent(EVENT_SIGNUP_SUCCESS)
     }
     // This cannot be loaded in `created` because Vue does not wait to resolve


### PR DESCRIPTION
My signup metrics had been flat as a pancake for some time even though I could verify from other sources that new users are indeed signing up every other day.

<img width="757" alt="Screen Shot 2021-08-07 at 6 59 28 PM" src="https://user-images.githubusercontent.com/600362/128601837-21a71b27-a13d-45ca-a3cd-6024dab9b777.png">

I had not bothered to figure out what broke, until yesterday.

Turns out that since we moved to the new API backend in June, the logic for when to fire a success event broke silently.

This should fix it.

The fix relies on a new column introduced in the backend for tracking user login count. When the user first signs up, the count starts at 1 (and is incremented on every successful login).