### PR TITLE
Fetch Inter font from Google Fonts

### DIFF
--- a/src/assets/app.css
+++ b/src/assets/app.css
@@ -1,4 +1,3 @@
-@import url('https://rsms.me/inter/inter.css');
 @import '~spinkit/spinkit.min.css';
 
 @tailwind base;

--- a/src/bookmarks.html
+++ b/src/bookmarks.html
@@ -7,6 +7,12 @@
     <link rel="icon" type="image/png" href="/icon16.png" sizes="16x16" />
     <link rel="icon" type="image/png" href="/icon32.png" sizes="32x32" />
     <link rel="icon" type="image/png" href="/icon48.png" sizes="48x48" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700&display=swap"
+      rel="stylesheet"
+    />
   </head>
   <body class="font-sans bg-default theme-light text-base text-default">
     <div id="app"></div>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -4,6 +4,11 @@ module.exports = {
   purge: ['./src/**/*.html', './src/**/*.vue'],
 
   theme: {
+    fontWeight: {
+      normal: 400,
+      medium: 500,
+      bold: 700,
+    },
     extend: {
       fontFamily: {
         sans: ['Inter', ...defaultTheme.fontFamily.sans],


### PR DESCRIPTION
This PR does a few things:

1. List down all the font weights we are using. This helps with design consistency.

2. Use Google Fonts to fetch our primary font -- Inter. Only fetch specific font weights that we actually use in the app.

3. Use the `<link>` tag to fetch web fonts. As it turns out, `@import` is not the [performant way to fetch fonts][stack-overflow].

[stack-overflow]: https://stackoverflow.com/questions/12316501/including-google-web-fonts-link-or-import/12380004#12380004

