### PR TITLE
Extend backend client to do exponential backoff retries on timeouts

### DIFF
--- a/src/api/backend/client.js
+++ b/src/api/backend/client.js
@@ -3,29 +3,78 @@ import axios from 'axios'
 export class Client {
   constructor(authWrapper, clientConfig, reqInterceptor) {
     this.auth = authWrapper
-    this.instance = axios.create(clientConfig)
+    const { maxRetryCount, errorRetryInterval, urlsToRetry, ...axiosConfig } =
+      clientConfig
+    this.maxRetryCount = maxRetryCount || 3
+    this.errorRetryInterval = errorRetryInterval || 250
+    this.urlsToRetry = urlsToRetry || []
+    this.instance = axios.create(axiosConfig)
     if (reqInterceptor) {
       this.instance.interceptors.request.use(reqInterceptor)
     }
+    // For tests
+    this.requestTimes = []
   }
 
-  async _request(config) {
-    try {
-      return await this.instance.request(config)
-    } catch (error) {
-      if (!error.response || error.response.status !== 403) {
-        throw error
-      }
-      if (config.doNotRefreshOnFailure) {
-        this.auth.expireToken()
-        throw error
-      }
-      await this.auth.tryRefreshToken()
-      return await this._request({
+  onAuthErrorRetry(config, error) {
+    if (config.doNotRefreshOnFailure) {
+      this.auth.expireToken()
+      throw error
+    }
+    return this.auth.tryRefreshToken().then(() => {
+      return this._request({
         ...config,
         doNotRefreshOnFailure: true,
       })
+    })
+  }
+
+  onErrorRetry({ retryCount, ...config }, error) {
+    const maxRetryCount = this.maxRetryCount
+    const currentRetryCount = retryCount
+    if (currentRetryCount > maxRetryCount) {
+      return Promise.reject(error)
     }
+
+    // Exponential backoff
+    const timeout =
+      ~~((Math.random() + 0.5) * (1 << Math.min(currentRetryCount, 8))) *
+      this.errorRetryInterval
+
+    return new Promise((resolve) => {
+      setTimeout(() => {
+        resolve(
+          this._request({
+            ...config,
+            retryCount: retryCount + 1,
+          })
+        )
+      }, timeout)
+    })
+  }
+
+  _request(config) {
+    this.requestTimes.push(Date.now())
+    return this.instance.request(config).catch((error) => {
+      if (error.response && error.response.status === 403) {
+        return this.onAuthErrorRetry(config, error)
+      }
+      if (
+        error.request &&
+        (error.code === 'ETIMEDOUT' || error.code === 'ECONNABORTED')
+      ) {
+        if (this.urlsToRetry.includes(config.url)) {
+          return this.onErrorRetry(
+            {
+              ...config,
+              retryCount: config.retryCount || 1,
+            },
+            error
+          )
+        }
+      }
+      throw error
+    })
   }
 
   _get(url) {

--- a/src/api/backend/client.test.js
+++ b/src/api/backend/client.test.js
@@ -1,0 +1,177 @@
+const http = require('http')
+import { Client } from './client'
+
+function getFakeAuth() {
+  const mockExpireToken = jest.fn()
+  const mockRefreshToken = jest.fn(() => Promise.resolve())
+  let fakeAuth = {
+    expireToken: mockExpireToken,
+    tryRefreshToken: mockRefreshToken,
+  }
+  return {
+    fakeAuth,
+    mockExpireToken,
+    mockRefreshToken,
+  }
+}
+
+const snooze = (ms) => new Promise((resolve) => setTimeout(resolve, ms))
+
+function printExpBackoff(requestTimes) {
+  let gaps = []
+  let [prev, ...rest] = requestTimes
+  rest.forEach((t) => {
+    gaps.push(t - prev)
+    prev = t
+  })
+  console.log(gaps)
+}
+
+describe('backend server retry handling', () => {
+  let server
+
+  afterEach(() => {
+    server.close()
+  })
+
+  test('happy case', async () => {
+    server = http
+      .createServer(function (req, res) {
+        res.writeHead(200)
+        res.end('Hello, World!')
+      })
+      .listen(8182)
+    const { fakeAuth, mockExpireToken, mockRefreshToken } = getFakeAuth()
+    const config = {
+      baseURL: 'http://localhost:8182',
+      timeout: 100,
+    }
+    const testClient = new Client(fakeAuth, config)
+    let resp = await testClient.loadUserData()
+    expect(resp.status).toEqual(200)
+    expect(mockExpireToken.mock.calls.length).toBe(0)
+    expect(mockRefreshToken.mock.calls.length).toBe(0)
+    expect(testClient.requestTimes.length).toBe(1)
+  })
+
+  it('fails after trying to refresh token on auth error', async () => {
+    server = http
+      .createServer(function (req, res) {
+        res.writeHead(403)
+        res.end('Logged out!')
+      })
+      .listen(8182)
+    const { fakeAuth, mockExpireToken, mockRefreshToken } = getFakeAuth()
+    const config = {
+      baseURL: 'http://localhost:8182',
+      timeout: 100,
+    }
+    const testClient = new Client(fakeAuth, config)
+    await expect(testClient.loadUserData()).rejects.toThrow(
+      /failed with status code 403/
+    )
+    expect(mockExpireToken.mock.calls.length).toBe(1)
+    expect(mockRefreshToken.mock.calls.length).toBe(1)
+    expect(testClient.requestTimes.length).toBe(2)
+  })
+
+  it('succeeds when backend gives new token on auth error', async () => {
+    let requestCount = 0
+    server = http
+      .createServer(function (req, res) {
+        if (requestCount === 0) {
+          requestCount += 1
+          res.writeHead(403)
+          res.end('Logged out!')
+        } else {
+          res.writeHead(200)
+          res.end('Hello, World!')
+        }
+      })
+      .listen(8182)
+    const { fakeAuth, mockExpireToken, mockRefreshToken } = getFakeAuth()
+    const config = {
+      baseURL: 'http://localhost:8182',
+      timeout: 100,
+    }
+    const testClient = new Client(fakeAuth, config)
+    let resp = await testClient.loadUserData()
+    expect(resp.status).toEqual(200)
+    expect(mockExpireToken.mock.calls.length).toBe(0)
+    expect(mockRefreshToken.mock.calls.length).toBe(1)
+    expect(testClient.requestTimes.length).toBe(2)
+  })
+
+  it('does not retry any other error', async () => {
+    server = http
+      .createServer(async function (req, res) {
+        await snooze(20)
+        res.writeHead(200)
+        res.end('Hello, World!')
+      })
+      .listen(8182)
+    const { fakeAuth, mockExpireToken, mockRefreshToken } = getFakeAuth()
+    const config = {
+      baseURL: 'http://localhost:8182',
+      timeout: 10,
+    }
+    const testClient = new Client(fakeAuth, config)
+    await expect(testClient.loadUserData()).rejects.toThrow(
+      /timeout of 10ms exceeded/
+    )
+    expect(mockExpireToken.mock.calls.length).toBe(0)
+    expect(mockRefreshToken.mock.calls.length).toBe(0)
+    expect(testClient.requestTimes.length).toBe(1)
+  })
+
+  it('does exponential backoff retries when url is allowlisted', async () => {
+    server = http
+      .createServer(async function (req, res) {
+        await snooze(20)
+        res.writeHead(200)
+        res.end('Hello, World!')
+      })
+      .listen(8182)
+    const { fakeAuth, mockExpireToken, mockRefreshToken } = getFakeAuth()
+    const config = {
+      baseURL: 'http://localhost:8182',
+      timeout: 10,
+      urlsToRetry: ['/users/me'],
+      errorRetryInterval: 15,
+    }
+    const testClient = new Client(fakeAuth, config)
+    await expect(testClient.loadUserData()).rejects.toThrow(
+      /timeout of 10ms exceeded/
+    )
+    expect(mockExpireToken.mock.calls.length).toBe(0)
+    expect(mockRefreshToken.mock.calls.length).toBe(0)
+    expect(testClient.requestTimes.length).toBe(4)
+  })
+
+  it('succeeds on third try when doing exponential backoff retries', async () => {
+    let requestCount = 0
+    server = http
+      .createServer(async function (req, res) {
+        requestCount += 1
+        if (requestCount < 3) {
+          await snooze(20)
+        }
+        res.writeHead(200)
+        res.end('Hello, World!')
+      })
+      .listen(8182)
+    const { fakeAuth, mockExpireToken, mockRefreshToken } = getFakeAuth()
+    const config = {
+      baseURL: 'http://localhost:8182',
+      timeout: 10,
+      urlsToRetry: ['/users/me'],
+      errorRetryInterval: 15,
+    }
+    const testClient = new Client(fakeAuth, config)
+    let resp = await testClient.loadUserData()
+    expect(resp.status).toEqual(200)
+    expect(mockExpireToken.mock.calls.length).toBe(0)
+    expect(mockRefreshToken.mock.calls.length).toBe(0)
+    expect(testClient.requestTimes.length).toBe(3)
+  })
+})

--- a/src/api/backend/index.js
+++ b/src/api/backend/index.js
@@ -17,4 +17,19 @@ export const clientConfig = {
 
   // `xsrfHeaderName` is the name of the http header that carries the xsrf token value
   xsrfHeaderName: 'X-CSRF-Token',
+
+  //////////////////////////////////////////////////////////////////////////////
+  // Below are custom options defined in client.js
+
+  // Client will only retry these urls.
+  urlsToRetry: ['/bookmarks/add'],
+
+  // Total # of requests made will be `maxRetryCount` + 1
+  maxRetryCount: 3,
+
+  // Retry interval specified in ms. The client does random exponential backoff
+  // on timeout errors. The gap gets larger and larger -- second request will be
+  // made at 500ms, then 1000ms and the last request will be made 2s after the
+  // first request.
+  errorRetryInterval: 250,
 }

--- a/src/api/backend/index.js
+++ b/src/api/backend/index.js
@@ -21,15 +21,14 @@ export const clientConfig = {
   //////////////////////////////////////////////////////////////////////////////
   // Below are custom options defined in client.js
 
-  // Client will only retry these urls.
+  // Client will only retry these urls
   urlsToRetry: ['/bookmarks/add'],
 
   // Total # of requests made will be `maxRetryCount` + 1
   maxRetryCount: 3,
 
-  // Retry interval specified in ms. The client does random exponential backoff
-  // on timeout errors. The gap gets larger and larger -- second request will be
-  // made at 500ms, then 1000ms and the last request will be made 2s after the
-  // first request.
-  errorRetryInterval: 250,
+  // Retry interval specified in ms. Note that this is just the initial value
+  // for the retry interval. The client uses exponential backoff to scale the
+  // interval between retries.
+  errorRetryInterval: 500,
 }


### PR DESCRIPTION
Backend API requests sometime time out. This PR implements retries to handle timeout errors on the client.

Not all requests are safe to retry -- so we have introduced an `urlsToRetry` config option to opt-in.

This PR opts-in the "create new bookmark" API operation (`/bookmarks/add`). It is probably NOT safe to retry but let's collect some data before making it idempotent.

Exponential backoff code adapted from [vercel/swr][swr].

[swr]: https://github.com/vercel/swr/blob/3bbbf5b86be0868963c12906816a7bc1ded84c15/src/utils/config.ts#L29