### PR TITLE
Drop tldjs as dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
     "lodash": "^4.17.13",
     "pinia": "^2.0.9",
     "tailwindcss": "^3.0.7",
-    "tldjs": "^2.3.1",
     "vue": "^3.2.0",
     "vue-query": "^1.15.0",
     "vue-router": "^4.0.0"

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -1,7 +1,0 @@
-const { getDomain } = require('tldjs')
-
-export function domainName(bookmarkURL) {
-  const url = new URL(bookmarkURL)
-  // Drop the subdomain, e.g. news.ycombinator.com -> ycombinator.com
-  return getDomain(url.hostname)
-}

--- a/yarn.lock
+++ b/yarn.lock
@@ -5757,11 +5757,6 @@ psl@^1.1.33:
   resolved "https://registry.yarnpkg.com/psl/-/psl-1.8.0.tgz#9326f8bcfb013adcc005fdff056acce020e51c24"
   integrity sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ==
 
-punycode@^1.4.1:
-  version "1.4.1"
-  resolved "https://registry.yarnpkg.com/punycode/-/punycode-1.4.1.tgz#c0d5a63b2718800ad8e1eb0fa5269c84dd41845e"
-  integrity sha1-wNWmOycYgArY4esPpSachN1BhF4=
-
 punycode@^2.1.0, punycode@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec"
@@ -6579,13 +6574,6 @@ thunky@^1.0.2:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/thunky/-/thunky-1.1.0.tgz#5abaf714a9405db0504732bbccd2cedd9ef9537d"
   integrity sha512-eHY7nBftgThBqOyHGVN+l8gF0BucP09fMo0oO/Lb0w1OF80dJv+lDVpXG60WMQvkcxAkNybKsrEIE3ZtKGmPrA==
-
-tldjs@^2.3.1:
-  version "2.3.1"
-  resolved "https://registry.yarnpkg.com/tldjs/-/tldjs-2.3.1.tgz#cf09c3eb5d7403a9e214b7d65f3cf9651c0ab039"
-  integrity sha512-W/YVH/QczLUxVjnQhFC61Iq232NWu3TqDdO0S/MtXVz4xybejBov4ud+CIwN9aYqjOecEqIy0PscGkwpG9ZyTw==
-  dependencies:
-    punycode "^1.4.1"
 
 tmp@^0.2.1:
   version "0.2.1"


### PR DESCRIPTION
We removed the domain extraction logic from frontend code in https://github.com/akshaykumar90/savory/pull/47. This library is not needed anymore.