### PR TITLE
Do not log event synchronously with javascript execution

### DIFF
--- a/src/pages/LandingPage.vue
+++ b/src/pages/LandingPage.vue
@@ -45,8 +45,11 @@ import {
   eventLogger,
 } from '../api/events'
 import { useAuth } from '../auth'
+import { onMounted } from 'vue'
 
-eventLogger.logEvent(EVENT_LANDING_LOAD, { page: 'webapp landing' })
+onMounted(() => {
+  eventLogger.logEvent(EVENT_LANDING_LOAD, { page: 'webapp landing' })
+})
 
 const { loginWithRedirect } = useAuth()
 


### PR DESCRIPTION
This might be firing unintentionally as written. This regression was introduced when we upgraded the app to Vue 3.

Fixing it by wrapping it in the `onMounted` hook.