### PR TITLE
Do not log landing event in case of logouts

### DIFF
--- a/src/auth/index.js
+++ b/src/auth/index.js
@@ -7,7 +7,7 @@ import { clientConfig } from '../api/backend'
 import { addXsrfHeader } from '../api/browser'
 
 const CALLBACK_URL = `${window.location.origin}/provider_cb`
-const LOGOUT_URL = window.location.origin
+const LOGOUT_URL = `${window.location.origin}/logout`
 
 export const useAuth = defineStore('auth', () => {
   const { userId, cleanState, updateState } = useAuthState()

--- a/src/pages/LandingPage.vue
+++ b/src/pages/LandingPage.vue
@@ -46,9 +46,14 @@ import {
 } from '../api/events'
 import { useAuth } from '../auth'
 import { onMounted } from 'vue'
+import { useRoute } from 'vue-router'
+
+const route = useRoute()
 
 onMounted(() => {
-  eventLogger.logEvent(EVENT_LANDING_LOAD, { page: 'webapp landing' })
+  if (!route.query.logout) {
+    eventLogger.logEvent(EVENT_LANDING_LOAD, { page: 'webapp landing' })
+  }
 })
 
 const { loginWithRedirect } = useAuth()

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -45,7 +45,7 @@ export const getRouter = () => {
         path: '/logout',
         name: 'logout',
         beforeEnter: (to, from, next) => {
-          next({ name: 'landing' })
+          next({ name: 'landing', query: { logout: true } })
         },
       },
       {


### PR DESCRIPTION
It turns out that we were not using the `/logout` route in the app.

