### PR TITLE
Mobile layout does not need margin

### DIFF
--- a/src/layouts/AppLayout.vue
+++ b/src/layouts/AppLayout.vue
@@ -21,7 +21,7 @@
       ></TopToolbar>
     </transition>
   </div>
-  <div class="mx-2 flex gap-4">
+  <div class="flex gap-4 sm:mx-2">
     <div class="hidden sm:block sm:flex-shrink-0">
       <div class="top-16 w-64">
         <NavSidebar></NavSidebar>


### PR DESCRIPTION
This is needed because on mobile, we want the layout stretched edge-to-edge without a lot of space on either side.

I accidentally removed this piece of code in #54. I thought that `sm:` without any other responsive layout modifier for margin was a no-op. I was wrong. I forgot that the design is mobile-first, therefore this piece of code was making sure that mobile layout has zero margin (which is the default value for margins). Only starting with `sm` size, add a margin.