### PR TITLE
Remove top-16 from sidebar

### DIFF
--- a/src/layouts/AppLayout.vue
+++ b/src/layouts/AppLayout.vue
@@ -23,7 +23,7 @@
   </div>
   <div class="flex gap-4 sm:mx-2">
     <div class="hidden sm:block sm:flex-shrink-0">
-      <div class="top-16 w-64">
+      <div class="w-64">
         <NavSidebar></NavSidebar>
       </div>
     </div>


### PR DESCRIPTION
We changed the sidebar to not use `position: fixed` in https://github.com/akshaykumar90/savory/pull/54. The `top-16` has no effect in the default positioning model, neither is it required anymore.