### PR TITLE
Fix thundering herd of individual get bookmark requests

### DIFF
--- a/src/components/BookmarkRow.vue
+++ b/src/components/BookmarkRow.vue
@@ -1,5 +1,5 @@
 <template>
-  <li class="flex items-start gap-2 py-4" @click="">
+  <li class="flex items-start gap-2 py-4" v-if="isSuccess">
     <button>
       <MenuAlt2Icon
         v-if="!selected"
@@ -84,7 +84,7 @@ export default {
   props: ['bookmarkId', 'site', 'tags', 'title'],
   setup(props) {
     const store = useSelectionStore()
-    const { data } = useBookmark(props.bookmarkId)
+    const { isSuccess, data } = useBookmark(props.bookmarkId)
     const selected = computed(() => store.selectedIds.has(props.bookmarkId))
     const tagsDialog = ref(null)
     let deleteConfirmation = inject('deleteConfirmation')
@@ -101,6 +101,7 @@ export default {
     })
     return {
       bookmark: data,
+      isSuccess,
       timeString,
       onDelete,
       tagsDialog,

--- a/src/composables/useBookmark.js
+++ b/src/composables/useBookmark.js
@@ -29,6 +29,19 @@ export function useDeleteBookmarks() {
   )
 }
 
+// The `useBookmark` composable is a hack, but it's a beautiful hack. This
+// composable acts as an abstraction to lookup a bookmark id in the bookmarks
+// cache maintained by vue-query.
+//
+// We never want to individually retrieve a bookmark row from the backend
+// because we already have the data client-side in the form of an entire page of
+// bookmarks. Individual rows fetching their own data also has the potential of
+// causing a thundering herd at the backend which is never a good thing.
+//
+// To avoid ever fetching data, we have set `enabled` to false. This ensures
+// that this query will never automatically fetch on mount or automatically
+// refetch in the background. Instead, data for this query is set manually in
+// the `useBookmarksPage` composable.
 export function useBookmark(bookmarkId) {
   const key = reactive(['bookmarks', bookmarkId])
   return useQuery(
@@ -38,7 +51,7 @@ export function useBookmark(bookmarkId) {
       return resp.data
     },
     {
-      staleTime: Infinity,
+      enabled: false,
     }
   )
 }

--- a/src/composables/useBulkEditBookmarks.js
+++ b/src/composables/useBulkEditBookmarks.js
@@ -37,11 +37,6 @@ function useBulkAddTag() {
         rollback()
       }
     },
-    onSettled: (data, error, { bookmarkIds }) => {
-      bookmarkIds.forEach((bookmarkId) =>
-        queryClient.invalidateQueries(['bookmarks', bookmarkId])
-      )
-    },
   })
 }
 
@@ -78,11 +73,6 @@ function useBulkRemoveTag() {
       if (rollback) {
         rollback()
       }
-    },
-    onSettled: (data, error, { bookmarkIds }) => {
-      bookmarkIds.forEach((bookmarkId) =>
-        queryClient.invalidateQueries(['bookmarks', bookmarkId])
-      )
     },
   })
 }


### PR DESCRIPTION
There was a race condition where we were assuming that fetching bookmarks for a page will always set query data for individual bookmark BEFORE the bookmark rows are mounted. But that ordering was never guaranteed in code. If the bookmark rows mounted before the query data was set, those 100 bookmarks (or whatever number of bookmarks in that page) would individually fetch their data at the same time causing the thundering herd.

That problem is now fixed by disabling that query from ever fetching automatically. The data for that query continues to be manually set via the upstream `useBookmarksPage` composable.

The second thing is that after looking closely, we realized that we never want the refresh requests for those individual bookmarks anyway. The API endpoint was added so that an individual bookmark can be refreshed after adding or removing a tag but in the last 6 months, we have realized there are more downsides than upsides. (e.g. flickering of tags in the edit tags dialog).

Indeed, we fixed this flickering issue while editing a single bookmark in #53. Now doing the same thing for bulk edit bookmarks dialog.