### PR TITLE
Prefetch tags data on initial load

### DIFF
--- a/src/composables/useTags.js
+++ b/src/composables/useTags.js
@@ -1,31 +1,37 @@
-import { useQuery } from 'vue-query'
+import { useQuery, useQueryClient } from 'vue-query'
+
+const TAGS_QUERY_KEY = ['tags']
+
+const TAGS_QUERY_OPTIONS = {
+  // Prevent `useTags` query from being garbage collected. This query powers
+  // tags autocomplete.
+  //
+  // Since this query is part of the EditTags component which is not always
+  // mounted, these queries become "inactive" and by default are garbage
+  // collected after 5 minutes. This is not great for user experience
+  // because users will see a lag in autocomplete when opening the edit tags
+  // dialog after 5 minutes.
+  //
+  // Setting this to Infinity means the tags cache sticks around and
+  // autocomplete always works. Note that the query will be refreshed on
+  // mounting the EditTags component.
+  cacheTime: Infinity,
+}
+
+async function tagsCount() {
+  let resp = await ApiClient.getTagsCount()
+  let result = {}
+  for (const { name, count } of resp.data) {
+    result[name] = count
+  }
+  return result
+}
+
+export function prefetchTags() {
+  const queryClient = useQueryClient()
+  queryClient.prefetchQuery(TAGS_QUERY_KEY, tagsCount, TAGS_QUERY_OPTIONS)
+}
 
 export function useTags() {
-  const key = ['tags']
-  return useQuery(
-    key,
-    async () => {
-      let resp = await ApiClient.getTagsCount()
-      let result = {}
-      for (const { name, count } of resp.data) {
-        result[name] = count
-      }
-      return result
-    },
-    {
-      // Prevent `useTags` query from being garbage collected. This query powers
-      // tags autocomplete.
-      //
-      // Since this query is part of the EditTags component which is not always
-      // mounted, these queries become "inactive" and by default are garbage
-      // collected after 5 minutes. This is not great for user experience
-      // because users will see a lag in autocomplete when opening the edit tags
-      // dialog after 5 minutes.
-      //
-      // Setting this to Infinity means the tags cache sticks around and
-      // autocomplete always works. Note that the query will be refreshed on
-      // mounting the EditTags component.
-      cacheTime: Infinity,
-    }
-  )
+  return useQuery(TAGS_QUERY_KEY, tagsCount, TAGS_QUERY_OPTIONS)
 }

--- a/src/pages/BookmarksPage.vue
+++ b/src/pages/BookmarksPage.vue
@@ -25,6 +25,7 @@ import { computed, onMounted, watch } from 'vue'
 import { onBeforeRouteUpdate, useRoute } from 'vue-router'
 import { usePageStore } from '../stores/page'
 import { useQueryClient, useIsMutating } from 'vue-query'
+import { prefetchTags } from '../composables/useTags'
 
 export default {
   components: {
@@ -40,6 +41,12 @@ export default {
     const store = usePageStore()
     const queryClient = useQueryClient()
     const isMutating = useIsMutating()
+
+    // We prefetch tags here to avoid the first-time delay while interacting
+    // with the edit tags dialog. In contrast with `useQuery`, this call does
+    // not create a subscription. This is desired because otherwise we will be
+    // needlessly firing the get tags request on window refocus, etc.
+    prefetchTags()
 
     const showDrillDownCard = computed(() => {
       if (isLoading.value || isError.value) {


### PR DESCRIPTION
This will avoid any first-time delays interacting with the edit tags dialog

