### PR TITLE
Auth retry is triggered on 401 errors

### DIFF
--- a/src/api/backend/client.js
+++ b/src/api/backend/client.js
@@ -56,7 +56,7 @@ export class Client {
   _request(config) {
     this.requestTimes.push(Date.now())
     return this.instance.request(config).catch((error) => {
-      if (error.response && error.response.status === 403) {
+      if (error.response && error.response.status === 401) {
         return this.onAuthErrorRetry(config, error)
       }
       if (

--- a/src/api/backend/client.test.js
+++ b/src/api/backend/client.test.js
@@ -57,7 +57,7 @@ describe('backend server retry handling', () => {
   it('fails after trying to refresh token on auth error', async () => {
     server = http
       .createServer(function (req, res) {
-        res.writeHead(403)
+        res.writeHead(401)
         res.end('Logged out!')
       })
       .listen(8182)
@@ -68,7 +68,7 @@ describe('backend server retry handling', () => {
     }
     const testClient = new Client(fakeAuth, config)
     await expect(testClient.loadUserData()).rejects.toThrow(
-      /failed with status code 403/
+      /failed with status code 401/
     )
     expect(mockExpireToken.mock.calls.length).toBe(1)
     expect(mockRefreshToken.mock.calls.length).toBe(1)
@@ -81,7 +81,7 @@ describe('backend server retry handling', () => {
       .createServer(function (req, res) {
         if (requestCount === 0) {
           requestCount += 1
-          res.writeHead(403)
+          res.writeHead(401)
           res.end('Logged out!')
         } else {
           res.writeHead(200)


### PR DESCRIPTION
We are updating the backend to return 401 (instead of 403) for cases when re-authentication can fix the problem.

It can mean as simple as refreshing the access token using the refresh token, or in cases when refresh token has expired, prompting the user to log in again.