### PR TITLE
Do not invalidate pages query on deleting bookmarks

### DIFF
--- a/src/composables/useBookmark.js
+++ b/src/composables/useBookmark.js
@@ -21,9 +21,6 @@ export function useDeleteBookmarks() {
           }
         )
       },
-      onSettled: () => {
-        queryClient.invalidateQueries(['pages'])
-      },
     }
   )
 }


### PR DESCRIPTION
As we have seen in #60 and #53, invalidating queries becomes a user experience smell more than it helps.

In this particular case, if there is a timeout error when deleting a bookmark, the `invalidateQueries` call triggers a refetch of the `pages` query and the response might still have the bookmark in it. This bookmark will disappear again on the next fetch since the delete will have gone through the database.

Removing this invalidation step will fix this UX papercut.