### PR TITLE
Edit tags dialog highlights tags for current tag page

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "@babel/core": "^7.14.6",
     "@babel/plugin-syntax-dynamic-import": "^7.0.0",
     "@babel/preset-env": "^7.14.7",
+    "@testing-library/vue": "^6.6.1",
     "@vitejs/plugin-vue": "^2.0.1",
     "@vue/vue3-jest": "^27.0.0-alpha.4",
     "babel-core": "^7.0.0-bridge.0",

--- a/src/components/EditTags.vue
+++ b/src/components/EditTags.vue
@@ -6,6 +6,7 @@
         v-else
         v-for="tag in tags"
         :name="tag"
+        :accented="true"
         :showRemove="true"
         :onClick="onRemove"
       >

--- a/src/components/EditTags.vue
+++ b/src/components/EditTags.vue
@@ -5,8 +5,8 @@
       <tag-button
         v-else
         v-for="tag in tags"
-        :name="tag"
-        :accented="true"
+        :name="tag.name"
+        :accented="tag.accented"
         :showRemove="true"
         :onClick="onRemove"
       >
@@ -45,6 +45,8 @@ import useBulkEditBookmarks from '../composables/useBulkEditBookmarks'
 import useEditBookmark from '../composables/useEditBookmark'
 import { lookup } from '../lib/typeahead'
 import { useTags } from '../composables/useTags'
+import { tagsWithAccentBit } from '../lib/tagsRow'
+import { usePageStore } from '../stores/page'
 
 export default {
   components: {
@@ -58,6 +60,8 @@ export default {
     this.$refs.addTagInput.focus()
   },
   setup(props) {
+    const pageStore = usePageStore()
+
     const newTag = ref('')
 
     const tagSuggestion = ref('')
@@ -72,6 +76,9 @@ export default {
       ? useEditBookmark(props.bookmarkId)
       : { tags: ref(null), addTag: () => {}, removeTag: () => {} }
     const typeaheadActivationThreshold = 3
+    const displayTags = computed(() =>
+      tagsWithAccentBit(tags.value, pageStore.tags)
+    )
     const placeholder = computed(() => {
       if (
         !newTag.value.length ||
@@ -117,7 +124,7 @@ export default {
       newTag,
       addTagInput,
       placeholder,
-      tags,
+      tags: displayTags,
       onEnter,
       onTab,
       onRemove: removeTag,

--- a/src/components/EditTags.vue
+++ b/src/components/EditTags.vue
@@ -5,6 +5,7 @@
       <tag-button
         v-else
         v-for="tag in tags"
+        :key="tag.name"
         :name="tag.name"
         :accented="tag.accented"
         :showRemove="true"

--- a/src/components/TagButton.test.js
+++ b/src/components/TagButton.test.js
@@ -1,0 +1,39 @@
+/**
+ * @jest-environment jsdom
+ */
+import { render } from '@testing-library/vue'
+import TagButton from './TagButton'
+
+describe('tag button is rendered', () => {
+  test('base button', () => {
+    const { getByRole, debug } = render(TagButton, {
+      props: { name: 'first tag' },
+    })
+    const button = getByRole('button')
+    expect(button.classList.contains('bg-indigo-100')).toBeTruthy()
+  })
+
+  test('accent button', () => {
+    const { getByRole, debug } = render(TagButton, {
+      props: { name: 'first tag', accented: true },
+    })
+    const button = getByRole('button')
+    expect(button.classList.contains('bg-pink-100')).toBeTruthy()
+  })
+
+  test('base button with remove icon', () => {
+    const { getByRole, debug } = render(TagButton, {
+      props: { name: 'first tag', showRemove: true },
+    })
+    const button = getByRole('button')
+    expect(button.lastChild.classList.contains('text-indigo-400')).toBeTruthy()
+  })
+
+  test('accent button with remove icon', () => {
+    const { getByRole, debug } = render(TagButton, {
+      props: { name: 'first tag', accented: true, showRemove: true },
+    })
+    const button = getByRole('button')
+    expect(button.lastChild.classList.contains('text-pink-400')).toBeTruthy()
+  })
+})

--- a/src/components/TagButton.vue
+++ b/src/components/TagButton.vue
@@ -6,8 +6,8 @@
   >
     {{ name }}
     <span
-      class="ml-1 inline-flex h-4 w-4 flex-shrink-0 items-center justify-center rounded-md focus:outline-none"
-      :class="crossIconColors"
+      class="ml-1 inline-flex h-4 w-4 flex-shrink-0 items-center justify-center rounded-md focus:text-white focus:outline-none"
+      :class="removeIconColors"
       v-if="showRemove"
     >
       <span class="sr-only">Remove tag</span>
@@ -29,18 +29,25 @@ export default {
     onClick: Function,
   },
   setup(props) {
-    const baseColor = props.accented ? 'yellow' : 'indigo'
-    const buttonColors = ref([`bg-${baseColor}-100`, `text-${baseColor}-800`])
-    const crossIconColors = ref([
-      `text-${baseColor}-400`,
-      `hover:bg-${baseColor}-200`,
-      `hover:text-${baseColor}-500`,
-      `focus:bg-${baseColor}-500`,
-      'focus:text-white',
+    const baseColors = ref(['bg-indigo-100', 'text-indigo-800'])
+    const accentColors = ref(['bg-pink-100', 'text-pink-800'])
+    const baseRemoveIconColors = ref([
+      'text-indigo-400',
+      'hover:bg-indigo-200',
+      'hover:text-indigo-500',
+      'focus:bg-indigo-500',
+    ])
+    const accentRemoveIconColors = ref([
+      'text-pink-400',
+      'hover:bg-pink-200',
+      'hover:text-pink-500',
+      'focus:bg-pink-500',
     ])
     return {
-      buttonColors,
-      crossIconColors,
+      buttonColors: props.accented ? accentColors : baseColors,
+      removeIconColors: props.accented
+        ? accentRemoveIconColors
+        : baseRemoveIconColors,
     }
   },
 }

--- a/src/components/TagButton.vue
+++ b/src/components/TagButton.vue
@@ -1,11 +1,13 @@
 <template>
   <button
-    class="inline-flex items-center rounded-md bg-indigo-100 px-2.5 py-0.5 text-sm font-medium text-indigo-800"
+    class="inline-flex items-center rounded-md px-2.5 py-0.5 text-sm font-medium"
+    :class="buttonColors"
     @click="onClick(name)"
   >
     {{ name }}
     <span
-      class="ml-1 inline-flex h-4 w-4 flex-shrink-0 items-center justify-center rounded-md text-indigo-400 hover:bg-indigo-200 hover:text-indigo-500 focus:bg-indigo-500 focus:text-white focus:outline-none"
+      class="ml-1 inline-flex h-4 w-4 flex-shrink-0 items-center justify-center rounded-md focus:outline-none"
+      :class="crossIconColors"
       v-if="showRemove"
     >
       <span class="sr-only">Remove tag</span>
@@ -17,11 +19,29 @@
 </template>
 
 <script>
+import { ref } from 'vue'
+
 export default {
   props: {
     name: String,
+    accented: Boolean,
     showRemove: Boolean,
     onClick: Function,
+  },
+  setup(props) {
+    const baseColor = props.accented ? 'yellow' : 'indigo'
+    const buttonColors = ref([`bg-${baseColor}-100`, `text-${baseColor}-800`])
+    const crossIconColors = ref([
+      `text-${baseColor}-400`,
+      `hover:bg-${baseColor}-200`,
+      `hover:text-${baseColor}-500`,
+      `focus:bg-${baseColor}-500`,
+      'focus:text-white',
+    ])
+    return {
+      buttonColors,
+      crossIconColors,
+    }
   },
 }
 </script>

--- a/src/lib/tagsRow.js
+++ b/src/lib/tagsRow.js
@@ -1,6 +1,8 @@
 import _ from 'lodash'
 
 export function tagsWithAccentBit(allTags, pageTags) {
+  // Cannot use pullAll here because allTags will actually be a proxy, and it
+  // cannot be mutated.
   const tagsExcluded = _.difference(allTags, pageTags)
   let result = pageTags.map((t) => ({ name: t, accented: true }))
   result = result.concat(

--- a/src/lib/tagsRow.js
+++ b/src/lib/tagsRow.js
@@ -1,12 +1,11 @@
-import _ from 'lodash'
-
 export function tagsWithAccentBit(allTags, pageTags) {
-  // Cannot use pullAll here because allTags will actually be a proxy, and it
-  // cannot be mutated.
-  const tagsExcluded = _.difference(allTags, pageTags)
-  let result = pageTags.map((t) => ({ name: t, accented: true }))
+  let result = allTags
+    .filter((t) => pageTags.includes(t))
+    .map((t) => ({ name: t, accented: true }))
   result = result.concat(
-    tagsExcluded.map((t) => ({ name: t, accented: false }))
+    allTags
+      .filter((t) => !pageTags.includes(t))
+      .map((t) => ({ name: t, accented: false }))
   )
   return result
 }

--- a/src/lib/tagsRow.js
+++ b/src/lib/tagsRow.js
@@ -1,0 +1,10 @@
+import _ from 'lodash'
+
+export function tagsWithAccentBit(allTags, pageTags) {
+  const tagsExcluded = _.difference(allTags, pageTags)
+  let result = pageTags.map((t) => ({ name: t, accented: true }))
+  result = result.concat(
+    tagsExcluded.map((t) => ({ name: t, accented: false }))
+  )
+  return result
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -40,7 +40,7 @@
     promise-polyfill "^8.1.3"
     unfetch "^4.1.0"
 
-"@babel/code-frame@^7.0.0":
+"@babel/code-frame@^7.0.0", "@babel/code-frame@^7.10.4":
   version "7.18.6"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.18.6.tgz#3b25d38c89600baa2dcc219edfa88a74eb2c427a"
   integrity sha512-TDCmlK5eOvH+eH7cdAFlNXeVJqWIQ7gW9tY1GJIpUtFb6CmjVyq2VM3u71bOyR8CRihcCgMUYoDNyLXao3+70Q==
@@ -1084,7 +1084,7 @@
     "@babel/types" "^7.4.4"
     esutils "^2.0.2"
 
-"@babel/runtime@^7.12.5":
+"@babel/runtime@^7.12.5", "@babel/runtime@^7.15.4":
   version "7.19.0"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.19.0.tgz#22b11c037b094d27a8a2504ea4dcff00f50e2259"
   integrity sha512-eR8Lo9hnDS7tqkO7NsV+mKvCmv5boaXFSZ70DnfhcgiEne8hv9oCEd36Klw74EtizEqLsy4YnW8UWwpBVolHZA==
@@ -1462,10 +1462,38 @@
     match-sorter "^6.3.1"
     vue-demi "^0.13.11"
 
+"@testing-library/dom@^8.5.0":
+  version "8.19.0"
+  resolved "https://registry.yarnpkg.com/@testing-library/dom/-/dom-8.19.0.tgz#bd3f83c217ebac16694329e413d9ad5fdcfd785f"
+  integrity sha512-6YWYPPpxG3e/xOo6HIWwB/58HukkwIVTOaZ0VwdMVjhRUX/01E4FtQbck9GazOOj7MXHc5RBzMrU86iBJHbI+A==
+  dependencies:
+    "@babel/code-frame" "^7.10.4"
+    "@babel/runtime" "^7.12.5"
+    "@types/aria-query" "^4.2.0"
+    aria-query "^5.0.0"
+    chalk "^4.1.0"
+    dom-accessibility-api "^0.5.9"
+    lz-string "^1.4.4"
+    pretty-format "^27.0.2"
+
+"@testing-library/vue@^6.6.1":
+  version "6.6.1"
+  resolved "https://registry.yarnpkg.com/@testing-library/vue/-/vue-6.6.1.tgz#b28d0ce9c0228032873947a1a5a2b96fc9016096"
+  integrity sha512-vpyBPrHzKTwEGS7ehUC8/IXgnqTBEMk6jd52Gouf51arG2jUorPhmkbsxUwJOyxz6L0gj2ZcmWnznG1OJcTCDQ==
+  dependencies:
+    "@babel/runtime" "^7.15.4"
+    "@testing-library/dom" "^8.5.0"
+    "@vue/test-utils" "^2.0.0"
+
 "@tootallnate/once@1":
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/@tootallnate/once/-/once-1.1.2.tgz#ccb91445360179a04e7fe6aff78c00ffc1eeaf82"
   integrity sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==
+
+"@types/aria-query@^4.2.0":
+  version "4.2.2"
+  resolved "https://registry.yarnpkg.com/@types/aria-query/-/aria-query-4.2.2.tgz#ed4e0ad92306a704f9fb132a0cfcf77486dbe2bc"
+  integrity sha512-HnYpAE1Y6kRyKM/XkEuiRQhTHvkzMBurTHnpFLYLBGPIylZNPs9jJcuOOYWxPLJCSEtmZT0Y8rHDokKN7rRTig==
 
 "@types/babel__core@^7.0.0", "@types/babel__core@^7.1.14":
   version "7.1.14"
@@ -1832,6 +1860,11 @@
   version "3.2.26"
   resolved "https://registry.yarnpkg.com/@vue/shared/-/shared-3.2.26.tgz#7acd1621783571b9a82eca1f041b4a0a983481d9"
   integrity sha512-vPV6Cq+NIWbH5pZu+V+2QHE9y1qfuTq49uNWw4f7FDEeZaDU2H2cx5jcUZOAKW7qTrUS4k6qZPbMy1x4N96nbA==
+
+"@vue/test-utils@^2.0.0":
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/@vue/test-utils/-/test-utils-2.1.0.tgz#c2f646aa2d6ac779f79a83f18c5b82fc40952bfd"
+  integrity sha512-U4AxAD/tKJ3ajxYew1gkfEotpr96DE/gLXpbl+nPbsNRqGBfQZZA7YhwGoQNDPgon56v+IGZDrYq7pe3GDl9aw==
 
 "@vue/vue3-jest@^27.0.0-alpha.4":
   version "27.0.0-alpha.4"
@@ -2206,6 +2239,11 @@ argparse@^1.0.7:
   dependencies:
     sprintf-js "~1.0.2"
 
+aria-query@^5.0.0:
+  version "5.0.2"
+  resolved "https://registry.yarnpkg.com/aria-query/-/aria-query-5.0.2.tgz#0b8a744295271861e1d933f8feca13f9b70cfdc1"
+  integrity sha512-eigU3vhqSO+Z8BKDnVLN/ompjhf3pYzecKXz8+whRy+9gZu8n1TCGfwzQUUPnqdHl9ax1Hr9031orZ+UOEYr7Q==
+
 array-flatten@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/array-flatten/-/array-flatten-1.1.1.tgz#9a5f699051b1e7073328f2a008968b64ea2955d2"
@@ -2548,15 +2586,10 @@ camelcase@^6.2.0:
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-6.2.0.tgz#924af881c9d525ac9d87f40d964e5cea982a1809"
   integrity sha512-c7wVvbw3f37nuobQNtgsgG9POC9qMbNuMQmTCqZv23b6MIz0fcYpBiOlv9gEN/hdLdnZTDQhg6e9Dq5M1vKvfg==
 
-caniuse-lite@^1.0.30001219:
-  version "1.0.30001243"
-  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001243.tgz"
-  integrity sha512-vNxw9mkTBtkmLFnJRv/2rhs1yufpDfCkBZexG3Y0xdOH2Z/eE/85E4Dl5j1YUN34nZVsSp6vVRFQRrez9wJMRA==
-
-caniuse-lite@^1.0.30001272, caniuse-lite@^1.0.30001286:
-  version "1.0.30001291"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001291.tgz#08a8d2cfea0b2cf2e1d94dd795942d0daef6108c"
-  integrity sha512-roMV5V0HNGgJ88s42eE70sstqGW/gwFndosYrikHthw98N5tLnOTxFqMLQjZVRxTWFlJ4rn+MsgXrR7MDPY4jA==
+caniuse-lite@^1.0.30001219, caniuse-lite@^1.0.30001272, caniuse-lite@^1.0.30001286:
+  version "1.0.30001418"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001418.tgz"
+  integrity sha512-oIs7+JL3K9JRQ3jPZjlH6qyYDp+nBTCais7hjh0s+fuBwufc7uZ7hPYMXrDOJhV360KGMTcczMRObk0/iMqZRg==
 
 chalk@^2.0.0, chalk@^2.1.0:
   version "2.4.2"
@@ -3136,6 +3169,11 @@ dns-txt@^2.0.2:
   integrity sha1-uR2Ab10nGI5Ks+fRB9iBocxGQrY=
   dependencies:
     buffer-indexof "^1.0.0"
+
+dom-accessibility-api@^0.5.9:
+  version "0.5.14"
+  resolved "https://registry.yarnpkg.com/dom-accessibility-api/-/dom-accessibility-api-0.5.14.tgz#56082f71b1dc7aac69d83c4285eef39c15d93f56"
+  integrity sha512-NMt+m9zFMPZe0JcY9gN224Qvk6qLIdqex29clBvc/y75ZBX9YA9wNK3frsYvu2DI1xcCIwxwnX+TlsJ2DSOADg==
 
 dom-converter@^0.2.0:
   version "0.2.0"
@@ -4971,6 +5009,11 @@ lru-cache@^6.0.0:
   dependencies:
     yallist "^4.0.0"
 
+lz-string@^1.4.4:
+  version "1.4.4"
+  resolved "https://registry.yarnpkg.com/lz-string/-/lz-string-1.4.4.tgz#c0d8eaf36059f705796e1e344811cf4c498d3a26"
+  integrity sha512-0ckx7ZHRPqb0oUm8zNr+90mtf9DQB60H1wMCjBtfi62Kl3a7JbHob6gA2bC+xRvZoOL+1hzUK8jeuEIQE8svEQ==
+
 magic-string@^0.25.7:
   version "0.25.7"
   resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.25.7.tgz#3f497d6fd34c669c6798dcb821f2ef31f5445051"
@@ -5672,6 +5715,15 @@ pretty-error@^4.0.0:
   dependencies:
     lodash "^4.17.20"
     renderkid "^3.0.0"
+
+pretty-format@^27.0.2:
+  version "27.5.1"
+  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-27.5.1.tgz#2181879fdea51a7a5851fb39d920faa63f01d88e"
+  integrity sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==
+  dependencies:
+    ansi-regex "^5.0.1"
+    ansi-styles "^5.0.0"
+    react-is "^17.0.1"
 
 pretty-format@^27.0.6:
   version "27.0.6"


### PR DESCRIPTION
This could be especially helpful when you are trying to delete the same tag from many bookmarks.

The workflow looks like this:

1. You go to that tag page
2. Use the edit tags dialog to remove the tag
3. Repeat

With this PR, the tag you want to delete would be the first one, and would be in a different accent color. Bulk edit tags dialog works in a similar way. This also works if there are more than 1 tag in the tag page. All those tags will come before any other tags in the edit tags dialog.
