### PR TITLE
Create a top-level `/login` route

### DIFF
--- a/src/auth/index.js
+++ b/src/auth/index.js
@@ -90,12 +90,12 @@ export const useAuth = defineStore('auth', () => {
    *
    * Preferred method for login on website.
    *
-   * @param initialScreen: Redirect initial state: 'signUp' or 'login'
+   * @param initialScreen: Redirect initial state: 'signup' or 'login'
    */
   const loginWithRedirect = (initialScreen) => {
     const loginOptions = {
       redirect_uri: CALLBACK_URL,
-      ...(initialScreen === 'signUp' && { screen_hint: 'signup' }),
+      ...(initialScreen === 'signup' && { screen_hint: 'signup' }),
     }
     return auth0Client.loginWithRedirect(loginOptions)
   }

--- a/src/pages/LandingPage.vue
+++ b/src/pages/LandingPage.vue
@@ -25,7 +25,7 @@
         </p>
         <button
           class="mt-4 select-none rounded bg-primary py-2 px-4 text-lg tracking-wide text-white hover:bg-blue-700 focus:outline-none"
-          @click="login('signUp')"
+          @click="login('signup')"
         >
           Create an Account
         </button>
@@ -59,7 +59,7 @@ onMounted(() => {
 const { loginWithRedirect } = useAuth()
 
 const login = (initialScreen) => {
-  if (initialScreen === 'signUp') {
+  if (initialScreen === 'signup') {
     eventLogger.logEvent(EVENT_SIGNUP_CTA, { page: 'webapp landing' })
   }
   loginWithRedirect(initialScreen)

--- a/src/pages/SignupPage.vue
+++ b/src/pages/SignupPage.vue
@@ -4,9 +4,13 @@ import { onMounted } from 'vue'
 
 const authStore = useAuth()
 
+const props = defineProps({
+  login: Boolean,
+})
+
 const { loginWithRedirect } = authStore
 
 onMounted(() => {
-  loginWithRedirect('signup')
+  loginWithRedirect(props.login ? 'login' : 'signup')
 })
 </script>

--- a/src/pages/SignupPage.vue
+++ b/src/pages/SignupPage.vue
@@ -7,6 +7,6 @@ const authStore = useAuth()
 const { loginWithRedirect } = authStore
 
 onMounted(() => {
-  loginWithRedirect('signUp')
+  loginWithRedirect('signup')
 })
 </script>

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -61,6 +61,17 @@ export const getRouter = () => {
         path: '/signup',
         name: 'signup',
         component: SignupPage,
+        props: { login: false },
+        beforeEnter: authGuard,
+        meta: {
+          requiredAuthState: 'logout',
+        },
+      },
+      {
+        path: '/login',
+        name: 'login',
+        component: SignupPage,
+        props: { login: true },
         beforeEnter: authGuard,
         meta: {
           requiredAuthState: 'logout',


### PR DESCRIPTION
We should have this endpoint for easy access to the login page.