### PR TITLE
Define constant for popup view in vite build

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -10,6 +10,11 @@ const certFilename = 'savory.test+4.pem'
 export default defineConfig({
   root: './src/pg',
   plugins: [vue()],
+  define: {
+    'process.env.SAVORY_APP_URL': JSON.stringify(
+      'https://app.savory.test:8080'
+    ),
+  },
   server: {
     host: 'app.savory.test',
     port: 8008,


### PR DESCRIPTION
This PR fixes local Vite playground setup.

The local Vite build was failing because vite =/= webpack and it does not pick up values from dotenv files. The `process.env.SAVORY_APP_URL` variable was introduced in https://github.com/akshaykumar90/savory/pull/78.

Instead of teaching Vite to read dotenv files, we decided to introduce environment variables piecemeal, only where strictly required.