### PR TITLE
`nope` has stopped working

### DIFF
--- a/src/components/EditTags.vue
+++ b/src/components/EditTags.vue
@@ -25,7 +25,7 @@
         <input
           type="text"
           v-model="newTag"
-          autocomplete="nope"
+          autocomplete="off"
           name="add-tag"
           id="add-tag"
           class="absolute top-0 left-0 block w-full rounded-md border-gray-300 bg-transparent text-default shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm"


### PR DESCRIPTION
Ah the joys of frontend development!

See this [stackoverflow](https://stackoverflow.com/questions/15738259/disabling-chrome-autofill) question for an illustrated history.

Apparently, since Chrome 106, `nope` has stopped working. Thankfully, `off` works.

Note that this hack was first put into place in https://github.com/akshaykumar90/savory/pull/33 which has more history and context.