### PR TITLE
Add support and help links to avatar menu

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,3 +10,4 @@ API_BASE_URL=https://api.savory.test:8081/api/v1
 API_COOKIES_URL=https://api.savory.test
 
 SAVORY_APP_URL=https://app.savory.test:8080
+MKT_SITE_URL=https://getsavory.co

--- a/src/components/AppHeader.vue
+++ b/src/components/AppHeader.vue
@@ -88,6 +88,21 @@
                 <MenuItems
                   class="absolute right-0 z-10 mt-2 w-48 origin-top-right rounded-md bg-white py-1 shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none"
                 >
+                  <MenuItem
+                    v-for="link in outboundLinks"
+                    :key="link.name"
+                    v-slot="{ active }"
+                  >
+                    <a
+                      :href="link.href"
+                      target="_blank"
+                      :class="[
+                        active ? 'bg-gray-100' : '',
+                        'block px-4 py-2 text-sm text-gray-700',
+                      ]"
+                      >{{ link.name }}</a
+                    >
+                  </MenuItem>
                   <MenuItem v-slot="{ active }">
                     <a
                       href="#"

--- a/src/components/AppHeader.vue
+++ b/src/components/AppHeader.vue
@@ -124,6 +124,16 @@
       </div>
       <div class="space-y-1 border-t border-gray-200 pt-2 pb-3">
         <DisclosureButton
+          v-for="link in outboundLinks"
+          :key="link.name"
+          as="a"
+          :href="link.href"
+          target="_blank"
+          class="block px-4 py-2 text-base font-medium text-gray-500 hover:bg-gray-100 hover:text-gray-800"
+        >
+          {{ link.name }}
+        </DisclosureButton>
+        <DisclosureButton
           as="a"
           href="#"
           @click.prevent="logout"
@@ -150,6 +160,7 @@ import { MagnifyingGlassIcon } from '@heroicons/vue/20/solid'
 import { Bars3Icon, XMarkIcon } from '@heroicons/vue/24/outline'
 import { ref, watch } from 'vue'
 import { navigation as navItems } from '../lib/navigation'
+import { outboundLinks } from '../lib/navigation'
 
 import _ from 'lodash'
 import { useRoute, useRouter } from 'vue-router'
@@ -205,6 +216,7 @@ export default {
       searchBar,
       focusSearch,
       navigation: navItems,
+      outboundLinks,
     }
   },
 }

--- a/src/lib/navigation.js
+++ b/src/lib/navigation.js
@@ -27,3 +27,16 @@ export const navigation = [
     href: { path: '/tag', query: { name: 'playlist' } },
   },
 ]
+
+const mkt_site_url = process.env.MKT_SITE_URL
+
+export const outboundLinks = [
+  {
+    name: 'Help',
+    href: `${mkt_site_url}/getting-started`,
+  },
+  {
+    name: 'Questions?',
+    href: `${mkt_site_url}/feedback`,
+  },
+]


### PR DESCRIPTION
These link to the [feedback][0] and [getting started][1] page on the marketing site.

- [x] Added the new environment variable `MKT_SITE_URL` to Vercel production configuration.

[0]: https://getsavory.co/feedback
[1]: https://getsavory.co/getting-started