### PR TITLE
Remove unnecessary event tracking from app

### DIFF
--- a/src/api/events/index.js
+++ b/src/api/events/index.js
@@ -1,7 +1,5 @@
 const amplitude = require('amplitude-js')
 
-export const EVENT_LANDING_LOAD = 'registration - load landing page'
-export const EVENT_SIGNUP_CTA = 'registration - click cta'
 export const EVENT_SIGNUP_SUCCESS = 'registration - successful signup'
 
 export const eventLogger = amplitude.getInstance()

--- a/src/pages/LandingPage.vue
+++ b/src/pages/LandingPage.vue
@@ -39,29 +39,11 @@
 </template>
 
 <script setup>
-import {
-  EVENT_SIGNUP_CTA,
-  EVENT_LANDING_LOAD,
-  eventLogger,
-} from '../api/events'
 import { useAuth } from '../auth'
-import { onMounted } from 'vue'
-import { useRoute } from 'vue-router'
-
-const route = useRoute()
-
-onMounted(() => {
-  if (!route.query.logout) {
-    eventLogger.logEvent(EVENT_LANDING_LOAD, { page: 'webapp landing' })
-  }
-})
 
 const { loginWithRedirect } = useAuth()
 
 const login = (initialScreen) => {
-  if (initialScreen === 'signup') {
-    eventLogger.logEvent(EVENT_SIGNUP_CTA, { page: 'webapp landing' })
-  }
   loginWithRedirect(initialScreen)
 }
 </script>


### PR DESCRIPTION
These 2 events are better tracked on the marketing site instead of here.