### PR TITLE
Don't retry too much?

### DIFF
--- a/src/composables/useBookmarksPage.js
+++ b/src/composables/useBookmarksPage.js
@@ -23,6 +23,7 @@ export default function useBookmarksPage() {
         itemsPerPage: itemsPerPage.value,
       }),
     {
+      retry: 1,
       keepPreviousData: true,
       // Search results are ordered by search ranking which may change
       // unpredictably between refetches, e.g. if new tags were added to some

--- a/src/composables/useTags.js
+++ b/src/composables/useTags.js
@@ -3,6 +3,7 @@ import { useQuery, useQueryClient } from '@tanstack/vue-query'
 const TAGS_QUERY_KEY = ['tags']
 
 const TAGS_QUERY_OPTIONS = {
+  retry: 1,
   // Prevent `useTags` query from being garbage collected. This query powers
   // tags autocomplete.
   //

--- a/src/pages/BookmarksPage.vue
+++ b/src/pages/BookmarksPage.vue
@@ -1,6 +1,10 @@
 <template>
   <ErrorScreen v-if="isError" :detail="errorDetail">
-    <PrimaryButton button-text="Retry" @click="onRetry">
+    <PrimaryButton
+      :button-text="isFetching ? 'Retrying' : 'Retry'"
+      :is-disabled="isFetching"
+      @click="onRetry"
+    >
       <ArrowPathIcon class="-ml-1 mr-2 h-5 w-5" aria-hidden="true" />
     </PrimaryButton>
   </ErrorScreen>
@@ -46,7 +50,8 @@ export default {
     DrillDownCard,
   },
   setup() {
-    const { isLoading, isError, error, refetch, data } = useBookmarksPage()
+    const { isLoading, isFetching, isError, error, refetch, data } =
+      useBookmarksPage()
 
     const route = useRoute()
 
@@ -100,6 +105,7 @@ export default {
 
     return {
       data,
+      isFetching,
       isError,
       errorDetail,
       onRetry: refetch,

--- a/src/pages/TagsPage.vue
+++ b/src/pages/TagsPage.vue
@@ -1,6 +1,10 @@
 <template>
   <ErrorScreen v-if="isError" :detail="errorDetail">
-    <PrimaryButton button-text="Retry" @click="onRetry">
+    <PrimaryButton
+      :button-text="isFetching ? 'Retrying' : 'Retry'"
+      :is-disabled="isFetching"
+      @click="onRetry"
+    >
       <ArrowPathIcon class="-ml-1 mr-2 h-5 w-5" aria-hidden="true" />
     </PrimaryButton>
   </ErrorScreen>
@@ -46,7 +50,7 @@ import ErrorScreen from '../components/ErrorScreen.vue'
 import PrimaryButton from '../components/PrimaryButton.vue'
 import { ArrowPathIcon } from '@heroicons/vue/20/solid'
 
-const { isError, error, data, refetch: onRetry } = useTags()
+const { isFetching, isError, error, data, refetch: onRetry } = useTags()
 
 const errorDetail = computed(() => {
   if (error.value) {


### PR DESCRIPTION
There is some bug in TanStack Query which triggers when keep previous data option is set and queries change when it is being retried in case of errors. The problem is that the user sees a flash of previous data when data is refetched on focus.

The "fix" is to make the "mid-retry" window narrow by... not retrying as much.

The default is 3 exponential back-off retries, which is a bit too long for our case anyway. With this change, we will only retry once, meaning 2 error requests before we show an error screen.

